### PR TITLE
Fix disconnecting peers

### DIFF
--- a/src/components/receiving-peer.js
+++ b/src/components/receiving-peer.js
@@ -18,8 +18,10 @@ class ReceivingPeer extends Component {
       onCode: code => this.setState({ code }),
       onConnected: () => this.setState({ connected: true }),
       onDisconnected: () => {
-        this.setState({ connected: false });
-        this.initializePeer();
+        if (this.peer) {
+          this.setState({ connected: false });
+          this.initializePeer();
+        }
       },
       onFile: file => this.setState({ file }),
     });
@@ -30,8 +32,11 @@ class ReceivingPeer extends Component {
   }
 
   componentWillUnmount() {
-    if (this.peer) {
-      this.peer.destroy();
+    const peer = this.peer;
+
+    if (peer) {
+      this.peer = null;
+      peer.destroy();
     }
   }
 

--- a/src/components/sending-peer.js
+++ b/src/components/sending-peer.js
@@ -17,8 +17,10 @@ class SendingPeer extends Component {
       onCode: code => this.setState({ code }),
       onConnected: () => this.setState({ connected: true }),
       onDisconnected: () => {
-        this.setState({ connected: false });
-        this.initializePeer();
+        if (this.peer) {
+          this.setState({ connected: false });
+          this.initializePeer();
+        }
       },
     });
   }
@@ -28,8 +30,11 @@ class SendingPeer extends Component {
   }
 
   componentWillUnmount() {
-    if (this.peer) {
-      this.peer.destroy();
+    const peer = this.peer;
+
+    if (peer) {
+      this.peer = null;
+      peer.destroy();
     }
   }
 


### PR DESCRIPTION
This fixes the `SendingPeer` and `ReceivingPeer` components so that they don't call `setState` after unmounting.
This was happening because `peer.destroy()` emits a `disconnect` event, which calls `setState`.